### PR TITLE
Missing height and width for cascade type id

### DIFF
--- a/haarcascade_frontalface_default.xml
+++ b/haarcascade_frontalface_default.xml
@@ -45,8 +45,8 @@
 <opencv_storage>
 <cascade type_id="opencv-cascade-classifier"><stageType>BOOST</stageType>
   <featureType>HAAR</featureType>
-  
-  
+  <height>24</height>
+  <width>24</width>
   <stageParams>
     <maxWeakCount>211</maxWeakCount></stageParams>
   <featureParams>


### PR DESCRIPTION
Added the missing height and width values for cascade type id..