### PR TITLE
sendmail() method of the SMTP object

### DIFF
--- a/Test.py
+++ b/Test.py
@@ -69,7 +69,19 @@ while True:
             cv2.imshow('Emotion Detector',frame)
     if cv2.waitKey(1) & 0xFF == ord('q'):
         break
-
+ender_mail = 'sender@fromdomain.com'    
+receivers_mail = ['reciever@todomain.com']    
+message = """From: From Person %s  
+To: To Person %s  
+Subject: Sending SMTP e-mail   
+This is a test e-mail message.  
+"""%(sender_mail,receivers_mail)    
+try:    
+   smtpObj = smtplib.SMTP('localhost')    
+   smtpObj.sendmail(sender_mail, receivers_mail, message)    
+   print("Successfully sent email")    
+except Exception:    
+   print("Error: unable to send email")    
 #Exit
 cap.release()
 cv2.destroyAllWindows()


### PR DESCRIPTION
There are cases where the emails are sent using the Gmail SMTP server. In this case, we can pass Gmail as the SMTP server instead of using the localhost with the port 587.