### PR TITLE
Update Classification_little_vgg.py

### DIFF
--- a/Classification_little_vgg.py
+++ b/Classification_little_vgg.py
@@ -65,6 +65,8 @@ def Fibonacci(n):
 		return Fibonacci(n-1) + Fibonacci(n-2)
 
 # Driver Program
+steps_per_epoch = nb_train_samples // batch_size,
+
 print(Fibonacci(9))
 
 # This code is contributed by Saket Modi


### PR DESCRIPTION
Error: There is a syntax error in the steps_per_epoch argument of model.fit_generator. The string is not closed properly.

Correct Line: Fix the syntax by removing the extra quotation mark and closing parenthesis.