### PR TITLE
Update Classification_little_vgg.py

### DIFF
--- a/Classification_little_vgg.py
+++ b/Classification_little_vgg.py
@@ -34,6 +34,7 @@ train_generator = train_datagen.flow_from_directory(
 					batch_size=batch_size,
 					class_mode='categorical',
 					shuffle=True)
+model.add(Conv2D(32, (3, 3), padding='same', kernel_initializer='he_normal', input_shape=(img_rows, img_cols, 1)))
 
 validation_generator = validation_datagen.flow_from_directory(
 							validation_data_dir,


### PR DESCRIPTION
Error in The ImageDataGenerator is configured for grayscale images (color_mode='grayscale'), but the input shape of the first convolutional layer in the model does not match the expected shape for grayscale images. You need to add the number of channels (1 for grayscale) to the input shape. so, Modify the input shape of the first convolutional layer to include the number of channels.