### PR TITLE
Update Classification_little_vgg.py

### DIFF
--- a/Classification_little_vgg.py
+++ b/Classification_little_vgg.py
@@ -7,8 +7,7 @@ main
 from keras.layers import Dense,Dropout,Activation,Flatten,BatchNormalization
 from keras.layers import conv2D,MaxPooling2D
 import os
-
-num_classes = 5
+img_rows, img_cols = 48, 48  num_classes = 5
 img_rows,img_cols = 48,48
 batch_size = 32
 


### PR DESCRIPTION
Error in The img_rows and img_cols variables are not defined before they are used in the target_size argument of train_generator and validation_generator. so Define img_rows and img_cols before using them.